### PR TITLE
Fix word order in copy-to-clipboard part

### DIFF
--- a/index.html
+++ b/index.html
@@ -1530,9 +1530,9 @@ function do_share(copy, shareType) {
             get_num_emoji(answer_correct[2]) +
             get_num_emoji(answer_correct[3]) + (shouldShowWords ? " " + answer[2].toUpperCase() + " - " + answer[3].toUpperCase() : "") + "\n" +
             get_num_emoji(answer_correct[4]) +
-            get_num_emoji(answer_correct[5]) + (shouldShowWords ? " " + answer[4].toUpperCase() + " - " + answer[6].toUpperCase() : "") + "\n" +
+            get_num_emoji(answer_correct[5]) + (shouldShowWords ? " " + answer[4].toUpperCase() + " - " + answer[5].toUpperCase() : "") + "\n" +
             get_num_emoji(answer_correct[6]) +
-            get_num_emoji(answer_correct[7]) + (shouldShowWords ? " " + answer[5].toUpperCase() + " - " + answer[7].toUpperCase() : "");
+            get_num_emoji(answer_correct[7]) + (shouldShowWords ? " " + answer[6].toUpperCase() + " - " + answer[7].toUpperCase() : "");
     }
 
     text_share += "\noctordle.com";


### PR DESCRIPTION
I noticed two words are shown swapped. Not sure this change is all that's needed to fix it, as I didn't read the whole code, just searched for this.