### PR TITLE
Fix DST computation, part II

### DIFF
--- a/index.html
+++ b/index.html
@@ -1295,7 +1295,7 @@ function restart() {
     if (daily_mode) {
         var date = (new Date());
         var startDate = (new Date('01/24/2022'));
-        seed = Math.floor((date.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
+        seed = Math.round((date.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
 
         printclear(acquire("game_title"), "daily octordle #" + seed.toString(10).padStart(4, "0"));
         window.last_daily = seed;


### PR DESCRIPTION
Fixes #6

Floor'ing the number of days since the start produces an incorrect
result between midnight and 1am:

> date
Date Fri Mar 18 2022 00:16:44 GMT-0700 (Pacific Daylight Saving Time)

> startDate
Date Mon Jan 24 2022 00:00:00 GMT-0800 (Pacific Standard Time)

> (date.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)
52.96995864583333

If you floored it, you would incorrectly get 52, rather than the correct
53. Thus, this commit changes it to use round instead.
